### PR TITLE
Expose Mip Map flags; Fix animation bug regarding bit sets

### DIFF
--- a/DtsTypes.py
+++ b/DtsTypes.py
@@ -447,7 +447,7 @@ def write_bit_set(fd, bits):
         fd.write(pack("<ii", numWords, numWords))
 
         for word in words:
-                fd.write(pack("<i", word))
+                fd.write(pack("<I", word))
 
 class Sequence:
         UniformScale = bit(0)

--- a/DtsTypes.py
+++ b/DtsTypes.py
@@ -432,7 +432,7 @@ class Material:
 
 def read_bit_set(fd):
         dummy, numWords = unpack("<ii", fd.read(8))
-        words = unpack(str(numWords) + "i", fd.read(4 * numWords))
+        words = unpack(str(numWords) + "I", fd.read(4 * numWords))
         total = len(words) * 32
         return [(words[i >> 5] & (1 << (i & 31))) != 0 for i in range(total)]
 

--- a/__init__.py
+++ b/__init__.py
@@ -344,6 +344,8 @@ class TorqueMaterialProperties(bpy.types.PropertyGroup):
     use_transparency: BoolProperty(name="Use Transparency")
     use_shadeless: BoolProperty(name="Shadeless")
     ifl_name: StringProperty(name="Name")
+    no_mip_mapping: BoolProperty(name="No Mip Mapping", default=False)
+    mip_map_zero_border: BoolProperty(name="Mip Map Zero Border", default=False)
 
 class TorqueMaterialPanel(bpy.types.Panel):
     bl_idname = "MATERIAL_PT_torque"
@@ -386,7 +388,14 @@ class TorqueMaterialPanel(bpy.types.Panel):
         sublayout.prop(obj.torque_props, "ifl_name", text="")
         sublayout = layout.column()
         sublayout.enabled = obj.torque_props.use_ifl
-    
+
+        row = layout.row()
+        sublayout = row.column()
+        sublayout.prop(obj.torque_props, "no_mip_mapping")
+        sublayout = row.column()
+        sublayout.enabled = not obj.torque_props.no_mip_mapping
+        sublayout.prop(obj.torque_props, "mip_map_zero_border")
+
 class TorqueVisProperties(bpy.types.PropertyGroup):
     vis_value: FloatProperty(name="Visibility", default=1, min=0, max=1)#, hard_min=0, hard_max=1)
 
@@ -400,7 +409,7 @@ class TorqueVisPanel(bpy.types.Panel):
     @classmethod
     def poll(cls, context):
         return context.view_layer.objects.active.type == "EMPTY"
-    
+
     def draw(self, context):
         obj = context.view_layer.objects.active
 
@@ -433,11 +442,11 @@ def register():
     bpy.utils.register_class(TorqueMaterialPanel)
     bpy.utils.register_class(TorqueVisProperties)
     bpy.utils.register_class(TorqueVisPanel)
-    
+
     bpy.types.Material.torque_props = PointerProperty(type=TorqueMaterialProperties)
-    
+
     bpy.types.Object.torque_vis_props = PointerProperty(type=TorqueVisProperties)
-    
+
     bpy.types.TOPBAR_MT_file_import.append(menu_func_import_dts)
     bpy.types.TOPBAR_MT_file_import.append(menu_func_import_dsq)
     bpy.types.TOPBAR_MT_file_export.append(menu_func_export_dts)

--- a/export_dts.py
+++ b/export_dts.py
@@ -89,8 +89,13 @@ def export_material(mat, shape):
         flags |= Material.SWrap
     if mat.torque_props.t_wrap:
         flags |= Material.TWrap
+
     flags |= Material.NeverEnvMap
-    flags |= Material.NoMipMap
+
+    if mat.torque_props.no_mip_mapping:
+        flags |= Material.NoMipMap
+    if mat.torque_props.mip_map_zero_border:
+        flags |= Material.MipMapZeroBorder
 
     if mat.torque_props.use_ifl:
         flags |= Material.IFLMaterial
@@ -240,7 +245,7 @@ def save_meshes(scene, shape, node_lookup, select_object):
         if bobj.users_collection:
             if len(bobj.users_collection) > 1:
                 print("Warning: Mesh {} is in multiple groups".format(bobj.name))
-			
+
             # gyt: make sure that this isn't one of the default collections
             if "collection" in bobj.users_collection[0].name.lower():
                 lod_name = "detail32"
@@ -674,7 +679,7 @@ def save(operator, context, filepath,
             for node in shape.nodes:
                 if hasattr(node, "animation_data") == True and node.armature is not None:
                     continue
-                
+
                 if hasattr(node, "bl_ob") == False or node.bl_ob is None:
                     vis = 1.0
                 else:
@@ -716,7 +721,7 @@ def save(operator, context, filepath,
 
                 if curves_scale and fcurves_keyframe_in_range(curves_scale, frame_start, frame_end):
                     seq.scaleMatters[index] = True
-                
+
                 if curves_vis and fcurves_keyframe_in_range(curves_vis, frame_start, frame_end):
                     seq.visMatters[index] = True
 
@@ -736,7 +741,7 @@ def save(operator, context, filepath,
 
                     if seq.scaleMatters[index]:
                         shape.node_aligned_scales.append(scale)
-                    
+
                     if seq.visMatters[index]:
                         shape.objectstates.append(ObjectState(vis, frame, 0))
 

--- a/import_dts.py
+++ b/import_dts.py
@@ -90,6 +90,11 @@ def import_material(color_source, dmat, filepath):
     if dmat.flags & Material.IFLMaterial:
         bmat.torque_props.use_ifl = True
 
+    if dmat.flags & Material.NoMipMap:
+        bmat.torque_props.no_mip_mapping = True
+    if dmat.flags & Material.MipMapZeroBorder:
+        bmat.torque_props.mip_map_zero_border = True
+
     # TODO: MipMapZeroBorder, IFLFrame, DetailMap, BumpMap, ReflectanceMap
     # AuxilaryMask?
 
@@ -418,14 +423,14 @@ def load(operator, context, filepath,
                         key.co = (
                             globalToolIndex + frameIndex * step,
                             vec[curve.array_index])
-            
+
             for mattersIndex, node in enumerate(nodesVis):
                 ob = node_obs_val[node]
                 curves = ob_vis_curves(ob)
 
                 # if not hasattr(ob, 'vis'):
                 #    ob['vis'] = shape.objectstates[seq.baseObjectState].vis
-                
+
                 ob.torque_vis_props.vis_value = shape.objectstates[seq.baseObjectState].vis
 
                 for frameIndex in range(seq.numKeyframes):
@@ -438,7 +443,7 @@ def load(operator, context, filepath,
                         key.co = (
                             globalToolIndex + frameIndex * step,
                             vis)
-                        
+
                         print(vis)
 
             # Insert a reference frame immediately before the animation


### PR DESCRIPTION
I modified the add-on to include UI options for the NoMipMap and MipMapZeroBorder flags as well as making the importer/exporter respect these flags.  Additionally, I made a single change in DtsTypes.py to pack the bit fields as unsigned integers rather than signed integers.  This corrects a bug with complex animations not working properly.